### PR TITLE
Optionally allow java to not be managed via the java cookbook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Attributes
   installed with the "`ant_library`" LWRP in the `install_source`
   recipe. The hash is the form `{"library-name" =>
   "http://url.to.library.jar.file"}`
+* `node['ant']['install_java']` - Whether or not to use the Java community
+  cookbook to install Java. Defaults to `true`.
 
 Resources/Providers
 ===================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,5 +21,6 @@ default['ant']['home']           = '/usr/local/ant'
 default['ant']['url']            = "http://archive.apache.org/dist/ant/binaries/apache-ant-#{node['ant']['version']}-bin.tar.gz"
 default['ant']['checksum']       = '664f48cfc9c4a9a832ec1dd9d2bed5229c0a9561e489dcb88841d75d3c2c7cf9'
 default['ant']['install_method'] = "package"
+default['ant']['install_java']   = true
 
 default['ant']['libraries']      = {"ant-contrib" => "http://search.maven.org/remotecontent?filepath=ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"}

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "java"
+include_recipe "java" if node['ant']['install_java']
 
 ant_pkgs = ["ant","ant-contrib","ivy"]
 

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "java"
+include_recipe "java" if node['ant']['install_java']
 include_recipe "ark"
 
 ark "ant" do


### PR DESCRIPTION
Allows for conditional exclusion of the java cookbook's default recipe for those of us who use other methods to configure our java environments.